### PR TITLE
Add support for multiple session indexes

### DIFF
--- a/SAML2/Core/Protocols.hs
+++ b/SAML2/Core/Protocols.hs
@@ -564,7 +564,7 @@ data LogoutRequest = LogoutRequest
   , logoutRequestReason :: Maybe (Identified XString LogoutReason)
   , logoutRequestNotOnOrAfter :: Maybe XS.DateTime
   , logoutRequestIdentifier :: SAML.PossiblyEncrypted SAML.Identifier
-  , logoutRequestSessionIndex :: Maybe XString
+  , logoutRequestSessionIndex :: [XString]
   } deriving (Eq, Show)
 
 instance XP.XmlPickler LogoutRequest where
@@ -574,7 +574,7 @@ instance XP.XmlPickler LogoutRequest where
       XP.>*< XP.xpAttrImplied "Reason" XP.xpickle
       XP.>*< XP.xpAttrImplied "NotOnOrAfter" XS.xpDateTime
       XP.>*< SAML.xpPossiblyEncrypted
-      XP.>*< XP.xpOption (xpElem "SessionIndex" XS.xpString))
+      XP.>*< XP.xpList (xpElem "SessionIndex" XS.xpString))
 instance DS.Signable LogoutRequest where
   signature' = samlProtocol' . DS.signature'
   signedID = protocolID . view samlProtocol'

--- a/test/Bindings/HTTPRedirect.hs
+++ b/test/Bindings/HTTPRedirect.hs
@@ -30,7 +30,7 @@ tests = U.test
       Nothing
       Nothing
       (NotEncrypted $ IdentifierName $ simpleNameID NameIDFormatPersistent "005a06e0-ad82-110d-a556-004005b13a2b")
-      (Just "1"))
+      ["1"])
     =<< decodeURI mempty (uri "https://ServiceProvider.com/SAML/SLO/Browser?SAMLRequest=fVFdS8MwFH0f7D%2BUvGdNsq62oSsIQyhMESc%2B%2BJYlmRbWpObeyvz3puv2IMjyFM7HPedyK1DdsZdb%2F%2BEHfLFfgwVMTt3RgTwzazIEJ72CFqRTnQWJWu7uH7dSLJjsg0ev%2FZFMlttiBWADtt6R%2BSyJr9msiRH7O70sCm31Mj%2Bo%2BC%2B1KA5GlEWeZaogSQMw2MYBKodrIhjLKONU8FdeSsZkVr6T5M0GiHMjvWCknqZXZ2OoPxF7kGnaGOuwxZ%2Fn4L9bY8NC%2By4du1XpRXnxPcXizSZ58KFTeHujEWkNPZylsh9bAMYYUjO2Uiy3jCpTCMo5M1StVjmN9SO150sl9lU6RV2Dp0vsLIy7NM7YU82r9B90PrvCf85W%2FwL8zSVQzAEAAA%3D%3D&RelayState=0043bfc1bc45110dae17004005b13a2b")
   , U.TestCase $ U.assertEqual "response"
     (LogoutResponse $ StatusResponseType


### PR DESCRIPTION
A logout request can contain multiple session indexes. So instead of having a `Maybe XString` for `logoutRequestSessionRequest`, we can have a `[XString]`.