### PR TITLE
Fix UTF8 encoding in XML signatures

### DIFF
--- a/SAML2/XML.hs
+++ b/SAML2/XML.hs
@@ -26,7 +26,7 @@ module SAML2.XML
   ) where
 
 import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Lazy.Char8 as BSLC
+import qualified Data.ByteString.Lazy.UTF8 as BSLU
 import Data.Default (Default(..))
 import qualified Data.Invertible as Inv
 import Data.Maybe (listToMaybe)
@@ -112,7 +112,7 @@ xmlToDoc = listToMaybe . HXT.runLA
   HXT.>>> HXT.removeWhiteSpace
   HXT.>>> HXT.neg HXT.isXmlPi
   HXT.>>> HXT.propagateNamespaces)
-  . BSLC.unpack -- XXX encoding?
+  . BSLU.toString
 
 docToSAML :: XP.XmlPickler a => HXT.XmlTree -> Either String a
 docToSAML = XP.unpickleDoc' XP.xpickle

--- a/hsaml2.cabal
+++ b/hsaml2.cabal
@@ -77,6 +77,7 @@ library
     semigroups,
     template-haskell,
     time,
+    utf8-string,
     x509,
     zlib
   pkgconfig-depends: libxml-2.0

--- a/hsaml2.cabal
+++ b/hsaml2.cabal
@@ -98,6 +98,7 @@ test-suite tests
   ghc-options: -Wall
   build-depends:
     base,
+    base64-bytestring,
     bytestring,
     cryptonite,
     hsaml2,
@@ -105,6 +106,7 @@ test-suite tests
     hxt-http,
     network-uri,
     semigroups,
+    string-conversions,
     time,
     x509,
     HUnit

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.2
+resolver: lts-14.12
 extra-deps:
 - invertible-hxt-0.1
 packages:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: lts-13.8
+resolver: lts-15.2
 extra-deps:
 - invertible-hxt-0.1
 packages:
-- location: .
+- .


### PR DESCRIPTION
Test case explains the issue, the fix is pretty straight-forward.  Alternatively, you might want to use the utf8 encoder from base, but that goes to `Text` and we need `String`.

04637c9 is optional and untested, feel free to ignore.  (I added it because the current `stack.yaml` doesn't appear to work any more with version 2.1.3.)

This change is also available from https://github.com/wireapp/hsaml2 master.  I wonder if we should make an attempt at consolidating the two again?