### PR TITLE
Signature verification

### DIFF
--- a/SAML2/XML/Signature.hs
+++ b/SAML2/XML/Signature.hs
@@ -203,9 +203,8 @@ verifySignature pks xid doc = do
   s@Signature{ signatureSignedInfo = si } <- either fail return $ docToSAML sx
   six <- applyCanonicalization (signedInfoCanonicalizationMethod si) (Just xpath) $ DOM.mkRoot [] [x]
   rl <- mapM (`verifyReference` x) (signedInfoReference si)
-  let keys = pks <> foldMap (foldMap keyinfo . keyInfoElements) (signatureKeyInfo s)
-      verified :: Maybe Bool
-      verified = verifyBytes keys (signatureMethodAlgorithm $ signedInfoSignatureMethod si) (signatureValue $ signatureSignatureValue s) six
+  let verified :: Maybe Bool
+      verified = verifyBytes pks (signatureMethodAlgorithm $ signedInfoSignatureMethod si) (signatureValue $ signatureSignatureValue s) six
       valid :: Bool
       valid = elem (Just xid) rl && all isJust rl
   return $ (valid &&) <$> verified

--- a/test/XML/Keys.hs
+++ b/test/XML/Keys.hs
@@ -1,6 +1,8 @@
-module XML.Keys (privkey1, pubkey1, pubkey2) where
+module XML.Keys (privkey1, pubkey1, pubkey2, privkeyRsa) where
 
 import SAML2.XML.Signature
+import qualified Crypto.PubKey.RSA as RSA
+import qualified Crypto.PubKey.RSA.Types as RSA
 import qualified Crypto.PubKey.DSA as DSA
 import System.IO.Unsafe (unsafePerformIO)
 
@@ -29,3 +31,13 @@ mkkeypair = do
       , DSA.params_g = 5421644057436475141609648488325705128047428394380474376834667300766108262613900542681289080713724597310673074119355136085795982097390670890367185141189796
       }
 
+privkeyRsa :: SigningKey
+_pubkeyRsa :: PublicKeys
+(privkeyRsa, _pubkeyRsa) = unsafePerformIO mkRsaKeypair
+
+mkRsaKeypair :: IO (SigningKey, PublicKeys)
+mkRsaKeypair = do
+  let rsaexp = 17
+      size = 96
+  (pubkey, privkey) <- RSA.generate size rsaexp
+  pure (SigningKeyRSA (RSA.KeyPair privkey), PublicKeys Nothing (Just pubkey))

--- a/test/XML/Keys.hs
+++ b/test/XML/Keys.hs
@@ -1,4 +1,4 @@
-module XML.Keys (privkey1, pubkey1, pubkey2, privkeyRsa) where
+module XML.Keys (privkey1, pubkey1, pubkey2, privkeyRsa, dummyPubkeyRSA) where
 
 import SAML2.XML.Signature
 import qualified Crypto.PubKey.RSA as RSA
@@ -34,6 +34,10 @@ mkkeypair = do
 privkeyRsa :: SigningKey
 _pubkeyRsa :: PublicKeys
 (privkeyRsa, _pubkeyRsa) = unsafePerformIO mkRsaKeypair
+
+_dummyPrivkeyRSA :: SigningKey
+dummyPubkeyRSA :: PublicKeys
+(_dummyPrivkeyRSA, dummyPubkeyRSA) = unsafePerformIO mkRsaKeypair
 
 mkRsaKeypair :: IO (SigningKey, PublicKeys)
 mkRsaKeypair = do

--- a/test/XML/Signature.hs
+++ b/test/XML/Signature.hs
@@ -5,6 +5,7 @@ module XML.Signature (tests) where
 import Control.Exception (SomeException, try)
 import Data.ByteString.Base64
 import Data.Either (isLeft)
+import Data.List (isInfixOf)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.String.Conversions
 import Data.Time
@@ -197,6 +198,16 @@ signVerifyTests = U.test
       let reqdoc = samlToDoc req'
       req'' :: AuthnRequest <- verifySAMLProtocol' pubkey1 reqdoc
       U.assertEqual "AuthnRequest with verifySAMLProtocol' (matching pubkeys)" req' req''
+
+  , U.TestCase $ do
+      let req = somereq
+      req' <- signSAMLProtocol privkeyRsa req
+      let reqdoc = samlToDoc req'
+      req'' :: Either SomeException AuthnRequest <- try $ verifySAMLProtocol' pubkey1 reqdoc
+      U.assertBool "AuthnRequest with verifySAMLProtocol' (bad pubkeys): isLeft"
+        $ isLeft req''
+      U.assertBool "AuthnRequest with verifySAMLProtocol' (bad pubkeys): error message matches"
+        $ "Left user error (signature verification failed: no matching key/alg pair.)" `isInfixOf` show req''
 
   , U.TestCase $ do
       let req = somereq

--- a/test/XML/Signature.hs
+++ b/test/XML/Signature.hs
@@ -211,6 +211,16 @@ signVerifyTests = U.test
 
   , U.TestCase $ do
       let req = somereq
+      req' <- signSAMLProtocol privkeyRsa req
+      let reqdoc = samlToDoc req'
+      req'' :: Either SomeException AuthnRequest <- try $ verifySAMLProtocol' (pubkey1 <> dummyPubkeyRSA) reqdoc
+      U.assertBool "AuthnRequest with verifySAMLProtocol' (bad pubkeys): isLeft"
+        $ isLeft req''
+      U.assertBool "AuthnRequest with verifySAMLProtocol' (bad pubkeys): error message matches"
+        $ "Left user error (signature verification failed: verification failed.)" `isInfixOf` show req''
+
+  , U.TestCase $ do
+      let req = somereq
       req' <- signSAMLProtocol privkey1 req
       let reqdoc = samlToDoc req'
       req'' :: Either SomeException AuthnRequest <- try $ verifySAMLProtocol' pubkey2 reqdoc

--- a/test/XML/Signature.hs
+++ b/test/XML/Signature.hs
@@ -188,13 +188,6 @@ signVerifyTests = U.test
   [ U.TestCase $ do
       let req = somereq
       req' <- signSAMLProtocol privkey1 req
-      let reqlbs = samlToXML req'
-      req'' :: AuthnRequest <- verifySAMLProtocol reqlbs
-      U.assertEqual "AuthnRequest with verifySAMLProtocol (no pubkeys)" req' req''
-
-  , U.TestCase $ do
-      let req = somereq
-      req' <- signSAMLProtocol privkey1 req
       let reqdoc = samlToDoc req'
       req'' :: AuthnRequest <- verifySAMLProtocol' pubkey1 reqdoc
       U.assertEqual "AuthnRequest with verifySAMLProtocol' (matching pubkeys)" req' req''


### PR DESCRIPTION
This PR intends to fix the following flaw in the SAML signature verification process.

hsaml2 maintains a pair of an optional RSA and an optional DSA key.
It may be used under the assumption that one could pass hsam2 an RSA key and an empty slot for the DSA key.

However, this has the effect that the DSA key from the signature itself will be added to the pair of trusted keys.
DSA has precedence over RSA, so the signature validation will be successful if (and only if) one provides a DSA public key matching her own signature. 